### PR TITLE
Set `-buildvcs=false` flag to fix Linux build

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
       - go-cache:/root/.cache/go-build
       - go-mod-cache:/go/pkg/mod
     working_dir: /app
-    command: bash -c "cd /app && mage -v && npm install && npm run build"
+    command: bash -c "cd /app && GOFLAGS=-buildvcs=false mage -v && npm install && npm run build"
 
   grafana:
     user: root


### PR DESCRIPTION
Before this fix, the build on Linux would fail with:

```
error obtaining VCS status: exit status 128
	Use -buildvcs=false to disable VCS stamping.
error obtaining VCS status: exit status 128
	Use -buildvcs=false to disable VCS stamping.
error obtaining VCS status: exit status 128
	Use -buildvcs=false to disable VCS stamping.
error obtaining VCS status: exit status 128
	Use -buildvcs=false to disable VCS stamping.
error obtaining VCS status: exit status 128
	Use -buildvcs=false to disable VCS stamping.
error obtaining VCS status: exit status 128
	Use -buildvcs=false to disable VCS stamping.
```

Setting this flag makes the build run successfully.