### PR TITLE
Hide details panel on result change

### DIFF
--- a/src/components/result/ResultTable.tsx
+++ b/src/components/result/ResultTable.tsx
@@ -5,7 +5,7 @@ import {
   TableRow,
 } from "../ui/table";
 import { TabularResult } from "../../lib/types";
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { RowDetailPanel } from "./RowDetailPanel";
 import { ChevronDownIcon, ChevronRightIcon } from "@heroicons/react/24/solid";
 
@@ -232,6 +232,11 @@ export function ResultTable({ tabularResult, onFilterChange, onOrderChange }: Re
   const [selectedRow, setSelectedRow] = useState<number | null>(null);
   const [isDetailOpen, setIsDetailOpen] = useState(false);
   const [hoveredRow, setHoveredRow] = useState<number | null>(null);
+
+  useEffect(() => {
+    setIsDetailOpen(false);
+    setSelectedRow(null);
+  }, [tabularResult]);
 
   const handleRowClick = (row: number) => {
     setSelectedRow(row);

--- a/src/components/result/RowDetailPanel.tsx
+++ b/src/components/result/RowDetailPanel.tsx
@@ -281,10 +281,11 @@ export function RowDetailPanel({ tabularResult, selectedRow, onClose, isOpen }: 
     }, 300);
   };
 
-
-
-
   if (selectedRow == null) {
+    return null;
+  }
+
+  if (selectedRow >= tabularResult.rows.length) {
     return null;
   }
 


### PR DESCRIPTION
It fixes the bug when the details panel is shown and the selected row is no longer available.