### PR TITLE
Fix missing collaps/expands icons 

### DIFF
--- a/src/components/styles/main.css
+++ b/src/components/styles/main.css
@@ -1,3 +1,9 @@
+@font-face {
+  font-family: 'codicon';
+  src: url('https://cdn.jsdelivr.net/npm/@vscode/codicons@0.0.35/dist/codicon.ttf') format('truetype');
+}
+
+
 /* Reset */
 * {
   margin: 0;
@@ -326,4 +332,4 @@
   background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path d="M5 2H7V14H5V2ZM9 2H11V14H9V2Z" fill="%23CC8400"/></svg>') center center no-repeat;
   cursor: pointer;
   background-size: 12px;
-} 
+}


### PR DESCRIPTION
The collapse/expand buttons render fine now.

<img width="406" alt="Screenshot 2025-04-04 at 14 47 44" src="https://github.com/user-attachments/assets/bc0c0aba-dee2-4995-a6a1-79b53cfff5a8" />
