### PR TITLE
Remove 'sorting' buttons

### DIFF
--- a/src/components/App/ObservabilityQueryLanguageComponent.tsx
+++ b/src/components/App/ObservabilityQueryLanguageComponent.tsx
@@ -252,20 +252,6 @@ export default function ObservabilityQueryLanguageComponent() {
     setActiveQuery(q);
   }, [query, tableDefinitions, currentTable]);
 
-  const onOrderChange = useCallback((columnName: string, order: string) => {
-
-    const newOrderBy = `|> ORDER BY ${columnName} ${order}`;
-    const lines = query.split('\n');
-    const index = lines.map((line: string) => line.toLowerCase().startsWith('|> order by')).lastIndexOf(true);
-    if (index !== -1) {
-      lines[index] = newOrderBy;
-    } else {
-      lines.push(newOrderBy);
-    }
-    const q = lines.join('\n');
-    setQuery(q);
-    setActiveQuery(q);
-  }, [query]);
 
   const handleAiModalAccept = useCallback((query: string) => {
     console.log("handleAiModalAccept", query);
@@ -396,7 +382,6 @@ export default function ObservabilityQueryLanguageComponent() {
               tabularResult={tabularResult}
               transpiledSQL={transpiledSQL}
               onFilterChange={onFilterChange}
-              onOrderChange={onOrderChange}
             />
           </div>
 

--- a/src/components/result/ResultTable.tsx
+++ b/src/components/result/ResultTable.tsx
@@ -225,10 +225,9 @@ function CompactCell({ columns, cells, startIndex, onFilterChange }: { columns: 
 interface ResultTableProps {
   tabularResult: TabularResult | null;
   onFilterChange: (columnName: string, value: string, operator: string) => void;
-  onOrderChange: (columnName: string, order: string) => void;
 }
 
-export function ResultTable({ tabularResult, onFilterChange, onOrderChange }: ResultTableProps) {
+export function ResultTable({ tabularResult, onFilterChange }: ResultTableProps) {
   const [selectedRow, setSelectedRow] = useState<number | null>(null);
   const [isDetailOpen, setIsDetailOpen] = useState(false);
   const [hoveredRow, setHoveredRow] = useState<number | null>(null);
@@ -280,42 +279,6 @@ export function ResultTable({ tabularResult, onFilterChange, onOrderChange }: Re
                   gap: '8px'
                 }}>
                   <div style={{ flex: 1, textAlign: 'center' }}>{column}</div>
-                  {column !== 'More Details' && (
-                    <div style={{ display: 'flex', gap: '4px', alignItems: 'center', flexShrink: 0 }}>
-                      <div style={{ display: 'flex', alignItems: 'center' }}>
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            onOrderChange(column, 'ASC');
-                          }}
-                          style={{
-                            border: 'none',
-                            background: 'none',
-                            cursor: 'pointer',
-                            padding: '2px 0',
-                            color: '#ccccdc'
-                          }}
-                        >
-                          ↑
-                        </button>
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            onOrderChange(column, 'DESC');
-                          }}
-                          style={{
-                            border: 'none',
-                            background: 'none',
-                            cursor: 'pointer',
-                            padding: '2px 0',
-                            color: '#ccccdc'
-                          }}
-                        >
-                          ↓
-                        </button>
-                      </div>
-                    </div>
-                  )}
                 </div>
               </TableCell>
             ))}

--- a/src/components/result/Results.tsx
+++ b/src/components/result/Results.tsx
@@ -8,10 +8,9 @@ interface ResultsProps {
   tabularResult: TabularResult | null;
   transpiledSQL: string | null;
   onFilterChange: (columnName: string, value: string, operator: string) => void;
-  onOrderChange: (columnName: string, order: string) => void;
 }
 
-export function Results({ tabularResult, transpiledSQL, onFilterChange, onOrderChange }: ResultsProps) {
+export function Results({ tabularResult, transpiledSQL, onFilterChange}: ResultsProps) {
   const [showChart, setShowChart] = useState(false);
   const [canShowChart, setCanShowChart] = useState(false);
   const [showSQL, setShowSQL] = useState(false);
@@ -131,7 +130,6 @@ export function Results({ tabularResult, transpiledSQL, onFilterChange, onOrderC
         <ResultTable
           tabularResult={tabularResult}
           onFilterChange={onFilterChange}
-          onOrderChange={onOrderChange}
         />
       )}
     </div>


### PR DESCRIPTION
Clicking on the sorting button can break the query. We don't have a semantic analysis yet. We don't know how each pipe section affects the list of columns.